### PR TITLE
Updating dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,15 @@ on:
 jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
   build:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         setup: ['basic', 'lowest']
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -34,12 +34,12 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
       - name: Get Composer Cache Directory # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -62,10 +62,10 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,28 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## Unreleased
 
+### Added
+
+- New rules:
+
+| Fixer                                    | Value                                                                                                                                       | Description                                                                                                               |
+|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `no_trailing_comma_in_singleline`        | `true`                                                                                                                                      | If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma |
+| `single_class_element_per_statement`     | `['elements' => ['const', 'property']]`                                                                                                     | There MUST NOT be more than one property or constant declared per statement                                               |
+| `no_multiple_statements_per_line`        | `true`                                                                                                                                      | There must not be more than one statement per line                                                                        |
+| `single_space_around_construct`          | `['constructs_contain_a_single_space' => [], 'constructs_followed_by_a_single_space' => [], 'constructs_preceded_by_a_single_space' => []]` | Ensures a single space after language constructs                                                                          |
+| `multiline_whitespace_before_semicolons` | `['strategy' => 'no_multi_line']`                                                                                                           | Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls         |
+
+
 ### Changed
 
 - Minimal required PHP version now is `8.0`
 - Minimal version of the package `friendsofphp/php-cs-fixer` now is `v3.16.0`
+- Rule set `@PSR12` instead of `@PSR2`
+
+### Removed
+
+- Deprecated rules `no_trailing_comma_in_singleline_array` and `no_trailing_comma_in_list_call`
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 | `single_space_around_construct`          | `['constructs_contain_a_single_space' => [], 'constructs_followed_by_a_single_space' => [], 'constructs_preceded_by_a_single_space' => []]` | Ensures a single space after language constructs                                                                          |
 | `multiline_whitespace_before_semicolons` | `['strategy' => 'no_multi_line']`                                                                                                           | Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls         |
 
-
 ### Changed
 
 - Minimal required PHP version now is `8.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal required PHP version now is `8.0`
+- Minimal version of the package `friendsofphp/php-cs-fixer` now is `v3.16.0`
+
 ## v1.3.0
 
 ### Changed
@@ -27,38 +34,38 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - New rules:
 
-Fixer | Value | Description
------ | ----- | -----------
-`array_indentation` | `true` | Each element of an array must be indented exactly once
-`class_attributes_separation` | `['elements' => ['const', 'method', 'property']]` | Class, trait and interface elements must be separated with one blank line
-`combine_nested_dirname` | `true` | Replace multiple nested calls of dirname by only one call with second $level parameter. Requires PHP >= 7.0
-`comment_to_phpdoc` | `true` | Comments with annotation should be docblock when used on structural elements
-`escape_implicit_backslashes` | `['double_quoted' => true]` | Escape implicit backslashes in strings and heredocs to ease the understanding of which are special chars interpreted by PHP and which not
-`explicit_indirect_variable` | `true` | Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0
-`explicit_string_variable` | `true` | Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax
-`fopen_flag_order` | `true` | Order the flags in `fopen` calls, `b` and `t` must be last
-`fopen_flags` | `['b_mode' => true]` | The flags in `fopen` calls must omit `t`, and `b` must be omitted or included consistently
-`fully_qualified_strict_types` | `true` | Transforms imported FQCN parameters and return types in function arguments to short version
-`global_namespace_import` | `['import_classes' => false, 'import_constants' => false, 'import_functions' => false]` | Imports or fully qualifies global classes/functions/constants
-`lowercase_static_reference` | `true` | Class static references `self`, `static` and `parent` MUST be in lower case
-`magic_method_casing` | `true` | Magic method definitions and calls must be using the correct casing
-`method_chaining_indentation` | `true` | Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported
-`multiline_comment_opening_closing` | `true` | DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash
-`native_constant_invocation` | `['fix_built_in' => true]` | Add leading `\` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for `null`, `false` and `true`
-`native_function_type_declaration_casing` | `true` | Native type hints for functions should use the correct case
-`no_alternative_syntax` | `true` | Replace control structure alternative syntax to use braces
-`no_unset_cast` | `true` | Variables must be set `null` instead of using `(unset)` casting
-`nullable_type_declaration_for_default_null_value` | `['use_nullable_type_declaration' => true]` | Adds or removes `?` before type declarations for parameters with a default `null` value
-`phpdoc_line_span` | `['const' => 'multi', 'method' => 'multi', 'property' => 'multi']` | Changes doc blocks from single to multi line, or reversed. Works for class constants, properties and methods only
-`return_assignment` | `true` | Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method
-`set_type_to_cast` | `true` | Cast shall be used, not `settype`
-`simple_to_complex_string_variable` | `true` | Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`)
-`single_trait_insert_per_statement` | **`false`** | Each trait `use` must be done as single statement
-`standardize_increment` | `true` | Increment and decrement operators should be used if possible
-`static_lambda` | **`false`** | Lambdas not (indirect) referencing `$this` must be declared `static`
-`string_line_ending` | `true` | All multi-line strings must use correct line ending
-`native_function_invocation` | `['scope'  => 'namespaced', 'strict' => false]` | Add leading `\` before function invocation to speed up resolving
-`php_unit_expectation` | `['target' => '5.6']` | Usages of `->setExpectedException*` methods MUST be replaced by `->expectException*` methods
+| Fixer                                              | Value                                                                                   | Description                                                                                                                                                                           |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `array_indentation`                                | `true`                                                                                  | Each element of an array must be indented exactly once                                                                                                                                |
+| `class_attributes_separation`                      | `['elements' => ['const', 'method', 'property']]`                                       | Class, trait and interface elements must be separated with one blank line                                                                                                             |
+| `combine_nested_dirname`                           | `true`                                                                                  | Replace multiple nested calls of dirname by only one call with second $level parameter. Requires PHP >= 7.0                                                                           |
+| `comment_to_phpdoc`                                | `true`                                                                                  | Comments with annotation should be docblock when used on structural elements                                                                                                          |
+| `escape_implicit_backslashes`                      | `['double_quoted' => true]`                                                             | Escape implicit backslashes in strings and heredocs to ease the understanding of which are special chars interpreted by PHP and which not                                             |
+| `explicit_indirect_variable`                       | `true`                                                                                  | Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0                                                                                          |
+| `explicit_string_variable`                         | `true`                                                                                  | Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax                                                                                             |
+| `fopen_flag_order`                                 | `true`                                                                                  | Order the flags in `fopen` calls, `b` and `t` must be last                                                                                                                            |
+| `fopen_flags`                                      | `['b_mode' => true]`                                                                    | The flags in `fopen` calls must omit `t`, and `b` must be omitted or included consistently                                                                                            |
+| `fully_qualified_strict_types`                     | `true`                                                                                  | Transforms imported FQCN parameters and return types in function arguments to short version                                                                                           |
+| `global_namespace_import`                          | `['import_classes' => false, 'import_constants' => false, 'import_functions' => false]` | Imports or fully qualifies global classes/functions/constants                                                                                                                         |
+| `lowercase_static_reference`                       | `true`                                                                                  | Class static references `self`, `static` and `parent` MUST be in lower case                                                                                                           |
+| `magic_method_casing`                              | `true`                                                                                  | Magic method definitions and calls must be using the correct casing                                                                                                                   |
+| `method_chaining_indentation`                      | `true`                                                                                  | Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported                                                                      |
+| `multiline_comment_opening_closing`                | `true`                                                                                  | DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash |
+| `native_constant_invocation`                       | `['fix_built_in' => true]`                                                              | Add leading `\` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for `null`, `false` and `true`                   |
+| `native_function_type_declaration_casing`          | `true`                                                                                  | Native type hints for functions should use the correct case                                                                                                                           |
+| `no_alternative_syntax`                            | `true`                                                                                  | Replace control structure alternative syntax to use braces                                                                                                                            |
+| `no_unset_cast`                                    | `true`                                                                                  | Variables must be set `null` instead of using `(unset)` casting                                                                                                                       |
+| `nullable_type_declaration_for_default_null_value` | `['use_nullable_type_declaration' => true]`                                             | Adds or removes `?` before type declarations for parameters with a default `null` value                                                                                               |
+| `phpdoc_line_span`                                 | `['const' => 'multi', 'method' => 'multi', 'property' => 'multi']`                      | Changes doc blocks from single to multi line, or reversed. Works for class constants, properties and methods only                                                                     |
+| `return_assignment`                                | `true`                                                                                  | Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method                                                                 |
+| `set_type_to_cast`                                 | `true`                                                                                  | Cast shall be used, not `settype`                                                                                                                                                     |
+| `simple_to_complex_string_variable`                | `true`                                                                                  | Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`)                                                                  |
+| `single_trait_insert_per_statement`                | **`false`**                                                                             | Each trait `use` must be done as single statement                                                                                                                                     |
+| `standardize_increment`                            | `true`                                                                                  | Increment and decrement operators should be used if possible                                                                                                                          |
+| `static_lambda`                                    | **`false`**                                                                             | Lambdas not (indirect) referencing `$this` must be declared `static`                                                                                                                  |
+| `string_line_ending`                               | `true`                                                                                  | All multi-line strings must use correct line ending                                                                                                                                   |
+| `native_function_invocation`                       | `['scope'  => 'namespaced', 'strict' => false]`                                         | Add leading `\` before function invocation to speed up resolving                                                                                                                      |
+| `php_unit_expectation`                             | `['target' => '5.6']`                                                                   | Usages of `->setExpectedException*` methods MUST be replaced by `->expectException*` methods                                                                                          |
 
 - Excluded directories:
   - `deploy`

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5.5 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache git \

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "php": "^8.0",
+        "friendsofphp/php-cs-fixer": "^v3.16.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "~0.12.34"
+        "phpstan/phpstan": "^1.10"
     },
     "scripts": {
         "phpstan": "@php ./vendor/bin/phpstan analyze -c ./phpstan.neon.dist --no-progress --ansi",

--- a/config.php
+++ b/config.php
@@ -25,11 +25,13 @@ $excludes = require __DIR__ . '/cs_excludes.php';
 $config   = new \PhpCsFixer\Config('Avto Develops Code Style Fixer');
 
 $config
-    ->setFinder(PhpCsFixer\Finder::create()
-    ->exclude(\file_exists($user_excludes = $project_root_dir . '/.cs_excludes.php')
-        ? \array_replace_recursive($excludes, require $user_excludes)
-        : $excludes)
-    ->in($project_root_dir))
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude(\file_exists($user_excludes = $project_root_dir . '/.cs_excludes.php')
+                ? \array_replace_recursive($excludes, require $user_excludes)
+                : $excludes)
+            ->in($project_root_dir)
+    )
     ->setRiskyAllowed(true)
     ->setUsingCache(true)
     ->setRules(\file_exists($user_rules = $project_root_dir . '/.cs_rules.php')

--- a/config.php
+++ b/config.php
@@ -34,10 +34,7 @@ $config
     ->setUsingCache(true)
     ->setRules(\file_exists($user_rules = $project_root_dir . '/.cs_rules.php')
         ? \array_replace_recursive($rules, require $user_rules)
-        : $rules);
-
-if (! empty($cache_file_path)) {
-    $config->setCacheFile($cache_file_path);
-}
+        : $rules)
+    ->setCacheFile($cache_file_path);
 
 return $config;

--- a/cs_rules.php
+++ b/cs_rules.php
@@ -7,7 +7,7 @@
  * @see https://mlocati.github.io/php-cs-fixer-configurator/
  */
 return [
-    '@PSR2'                                            => true,
+    '@PSR12'                                           => true,
     '@PHP71Migration'                                  => true,
     'binary_operator_spaces'                           => [
         'operators' => [
@@ -45,13 +45,12 @@ return [
     'no_leading_import_slash'                          => true,
     'no_leading_namespace_whitespace'                  => true,
     'no_multiline_whitespace_around_double_arrow'      => true,
-    'no_trailing_comma_in_singleline_array'            => true,
+    'no_trailing_comma_in_singleline'                  => true,
     'no_null_property_initialization'                  => true,
     'no_spaces_after_function_name'                    => true,
     'no_short_bool_cast'                               => true,
     'no_singleline_whitespace_before_semicolons'       => true,
     'no_spaces_around_offset'                          => true,
-    'no_trailing_comma_in_list_call'                   => true,
     'no_unused_imports'                                => true, // Эта сюка глючила
     'no_whitespace_in_blank_line'                      => true,
     'no_useless_else'                                  => true,
@@ -140,7 +139,11 @@ return [
     // since v1.1.0
     'array_indentation'                                => true,
     'class_attributes_separation'                      => [
-        'elements' => ['const' => 'one', 'method' => 'one', 'property' => 'one'],
+        'elements' => [
+            'const'    => 'only_if_meta',
+            'method'   => 'one',
+            'property' => 'one',
+        ],
     ],
     'combine_nested_dirname'                           => true,
     'comment_to_phpdoc'                                => true,
@@ -181,4 +184,17 @@ return [
         'strict' => false,
     ],
     'php_unit_expectation'                             => ['target' => '5.6'],
+
+    // since v1.4.0
+    'single_class_element_per_statement'               => [
+        'elements' => [
+            'const',
+            'property',
+        ],
+    ],
+    'no_multiple_statements_per_line'                  => true,
+    'single_space_around_construct'                    => true,
+    'multiline_whitespace_before_semicolons'           => [
+        'strategy' => 'no_multi_line',
+    ],
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,7 @@ parameters:
   paths:
     - ./cs-fix
     - .
-  excludes_analyse:
+  excludePaths:
     - ./vendor/*
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:


### PR DESCRIPTION
## Description

Update minimal required PHP version to PHP 8.0 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Changed

- Minimal required PHP version now is 8.0
- Minimal version of the package friendsofphp/php-cs-fixer now is v3.16.0
