### PR TITLE
Config parameters changing for `Blank lines before namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- `single_blank_line_before_namespace` has been replaced with `blank_lines_before_namespace` according base package issue. [#7053]
+
+[#7053]:https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7053
+
 ## v1.4.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^v3.16.0"
+        "friendsofphp/php-cs-fixer": "^v3.18.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10"

--- a/cs_rules.php
+++ b/cs_rules.php
@@ -87,6 +87,7 @@ return [
     'single_line_comment_style'                        => true,
     'single_blank_line_at_eof'                         => true,
     'blank_lines_before_namespace'                     => true,
+    'single_blank_line_before_namespace'               => false, // deprecated
     'single_line_after_imports'                        => true,
     'single_quote'                                     => true,
     'space_after_semicolon'                            => true,

--- a/cs_rules.php
+++ b/cs_rules.php
@@ -86,7 +86,7 @@ return [
     'short_scalar_cast'                                => true,
     'single_line_comment_style'                        => true,
     'single_blank_line_at_eof'                         => true,
-    'single_blank_line_before_namespace'               => true,
+    'blank_lines_before_namespace'                     => true,
     'single_line_after_imports'                        => true,
     'single_quote'                                     => true,
     'space_after_semicolon'                            => true,


### PR DESCRIPTION
`single_blank_line_before_namespace` parameter has been added to `conflictMap` with `blank_lines_before_namespace`  in `friendsofphp/php-cs-fixer`, and also has been marked as deprecated.
This request replaces the parameter name to correct.