### PR TITLE
Use default settings for `string_implicit_backslashes` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Use `string_implicit_backslashes` rule instead of deprecated `escape_implicit_backslashes`
+- Use default settings for `string_implicit_backslashes` rule
 - Use `compact_nullable_type_declaration` rule instead of deprecated `compact_nullable_typehint`
 - Use `type_declaration_spaces` rule instead of deprecated `function_typehint_space`
 - Use `native_type_declaration_casing` rule instead of deprecated `native_function_type_declaration_casing`
 
 ### Removed
 
+- Deprecated rule `escape_implicit_backslashes`
 - Deprecated rule `single_blank_line_before_namespace`
 
 ## v1.5.0

--- a/cs_rules.php
+++ b/cs_rules.php
@@ -147,7 +147,6 @@ return [
     ],
     'combine_nested_dirname'                           => true,
     'comment_to_phpdoc'                                => true,
-    'string_implicit_backslashes'                      => ['double_quoted' => 'escape'],
     'explicit_indirect_variable'                       => true,
     'explicit_string_variable'                         => true,
     'fopen_flag_order'                                 => true,


### PR DESCRIPTION
### Changed

- Use default settings for `string_implicit_backslashes` rule

### Removed

- Deprecated rule `escape_implicit_backslashes`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
