### PR TITLE
Fix default console argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
-- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file [#21]
+- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file [#22]
 
-[#21]:https://github.com/avto-dev/php-cs-fixer/issues/21
+[#22]:https://github.com/avto-dev/php-cs-fixer/pull/22
 
 ## v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
-- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file
+- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file [#21]
+
+[#21]:https://github.com/avto-dev/php-cs-fixer/issues/21
 
 ## v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Fixed
+
+- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file
+
 ## v1.6.0
 
 ### Changed

--- a/cs-fix
+++ b/cs-fix
@@ -56,7 +56,7 @@ for ($i = 0; $i <= \count($argv) - 1; $i++) {
 // Initialize input arguments object
 $input = new \Symfony\Component\Console\Input\ArgvInput($user_config === null
     ? \array_merge([
-        null,
+        'php-cs-fixer',
         'fix',
         '--verbose',
         '--config',


### PR DESCRIPTION
## Description

Fix default argument for `cs-fix` CLI-command

Fixes #21 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Fixed

- Default argument for `Symfony\Component\Console\Input\ArgvInput` class in `cs-fix` file
