### PR TITLE
Update deprecated rule `PHP71Migration` in cs_rules.php

### DIFF
--- a/cs_rules.php
+++ b/cs_rules.php
@@ -8,7 +8,7 @@
  */
 return [
     '@PSR12'                                           => true,
-    '@PHP71Migration'                                  => true,
+    '@PHP7x1Migration'                                 => true,
     'binary_operator_spaces'                           => [
         'operators' => [
             '='  => 'align_single_space',


### PR DESCRIPTION
## Description


This changes fixed the warning:

```
- Rule set "@PHP71Migration" is deprecated. Use "@PHP7x1Migration" instead.
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
