### PR TITLE
Update rules set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       fail-fast: false
       matrix:
         setup: ['basic', 'lowest']
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Use `PHP7x1Migration` rule instead of deprecated `PHP71Migration`
+- Use `modifier_keywords` rule instead of deprecated `visibility_required`
+- Minimal version of the package `friendsofphp/php-cs-fixer` now is `v3.90`
+
+### Removed
+
+- Obsolete `version` in `docker-compose.yml`
+
 ## v1.6.1
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:8.0-alpine
+FROM php:8.4-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.5.5 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache git \

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": "^8.0",
-        "friendsofphp/php-cs-fixer": "^v3.54.0"
+        "friendsofphp/php-cs-fixer": "^v3.90"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.12"
     },
     "scripts": {
         "phpstan": "@php ./vendor/bin/phpstan analyze -c ./phpstan.neon.dist --no-progress --ansi",

--- a/cs_rules.php
+++ b/cs_rules.php
@@ -7,9 +7,9 @@
  * @see https://mlocati.github.io/php-cs-fixer-configurator/
  */
 return [
-    '@PSR12'                                           => true,
-    '@PHP71Migration'                                  => true,
-    'binary_operator_spaces'                           => [
+    '@PSR12'                                            => true,
+    '@PHP7x1Migration'                                  => true,
+    'binary_operator_spaces'                            => [
         'operators' => [
             '='  => 'align_single_space',
             '=>' => 'align_single_space',
@@ -97,7 +97,7 @@ return [
     'unary_operator_spaces'                            => true,
     'void_return'                                      => true,
     'ternary_to_null_coalescing'                       => true,
-    'visibility_required'                              => true,
+    'modifier_keywords'                                => ['elements' => ['const', 'method', 'property']],
     'whitespace_after_comma_in_array'                  => true,
     'ordered_imports'                                  => [
         'sort_algorithm' => 'length',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.2'
-
 volumes:
   composer-data:
 


### PR DESCRIPTION
## Description

### Changed

- Use `PHP7x1Migration` rule instead of deprecated `PHP71Migration`
- Use `modifier_keywords` rule instead of deprecated `visibility_required`
- Minimal version of the package `friendsofphp/php-cs-fixer` now is `v3.90`

### Removed

- Obsolete `version` in `docker-compose.yml`

Fixes #18

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
